### PR TITLE
`renderView` now tracks `beforeRender` and `afterRender` to zoom more accurately

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -49,7 +49,7 @@ export type IGraphViewProps = {
   readOnly?: boolean,
   selected: any[],
   showGraphControls?: boolean,
-  zoomDelay?: number,
+  initialZoomDur?: number,
   zoomDur?: number,
   canCreateEdge?: (startNode?: INode, endNode?: INode) => boolean,
   canDeleteEdge?: (selected: any) => boolean,


### PR DESCRIPTION
Cleans up `renderView`, adds `beforeRender` and `afterRender` callbacks to zoom when rendering is approximately complete.

Adds `visibility: 'hidden'` and `visibility: 'visible'` to `this.entities` while rendering is initially taking place so we don't get weird double buffering.

Adds unit tests for `renderView` to make sure `beforeRender` and `afterRender` are called normally.