### PR TITLE
clean up node and edge deletions within graph-view

### DIFF
--- a/__tests__/components/graph-util.test.js
+++ b/__tests__/components/graph-util.test.js
@@ -1,7 +1,7 @@
 // @flow
 
+import ReactDOM from 'react-dom';
 import GraphUtils from '../../src/utilities/graph-util';
-import { Edge } from '../../src';
 
 describe('GraphUtils class', () => {
   describe('getNodesMap method', () => {
@@ -130,19 +130,24 @@ describe('GraphUtils class', () => {
           removeChild: jasmine.createSpy(),
         },
       };
+      const element = {
+        querySelector: () => fakeElement,
+      };
 
-      spyOn(document, 'getElementById').and.returnValue(fakeElement);
-      const result = GraphUtils.removeElementFromDom('fake');
+      spyOn(ReactDOM, 'unmountComponentAtNode').and.returnValue(true);
+
+      const result = GraphUtils.removeElementFromDom(element, 'fake');
 
       expect(fakeElement.parentNode.removeChild).toHaveBeenCalledWith(
         fakeElement
       );
+      expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(fakeElement);
       expect(result).toEqual(true);
     });
 
     it("does nothing when it can't find the element", () => {
-      spyOn(document, 'getElementById').and.returnValue(undefined);
-      const result = GraphUtils.removeElementFromDom('fake');
+      const element = { querySelector: () => undefined };
+      const result = GraphUtils.removeElementFromDom(element, 'fake');
 
       expect(result).toEqual(false);
     });

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -302,12 +302,13 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
   deleteStartNode = () => {
     const graph = this.state.graph;
 
-    graph.nodes.splice(0, 1);
     // using a new array like this creates a new memory reference
     // this will force a re-render
-    graph.nodes = [...this.state.graph.nodes];
     this.setState({
-      graph,
+      graph: {
+        ...graph,
+        nodes: graph.nodes.slice(1),
+      },
     });
   };
 

--- a/src/utilities/graph-util.js
+++ b/src/utilities/graph-util.js
@@ -15,6 +15,7 @@
   limitations under the License.
 */
 
+import ReactDOM from 'react-dom';
 import { type IEdge } from '../components/edge';
 import { type INode } from '../components/node';
 import fastDeepEqual from 'fast-deep-equal';
@@ -94,10 +95,11 @@ class GraphUtils {
     }
   }
 
-  static removeElementFromDom(id: string) {
-    const container = document.getElementById(id);
+  static removeElementFromDom(element: any, id: string) {
+    const container = element.querySelector(`#${id}`);
 
     if (container && container.parentNode) {
+      ReactDOM.unmountComponentAtNode(container);
       container.parentNode.removeChild(container);
 
       return true;


### PR DESCRIPTION
- `graph-util::removeElementFromDom` now also calls `unmountComponentAtNode` so we're not laving behind elements in the `ReactDOM`
- cleans up deletion state in `graph-view`
- cleans up `examples/graph` to not mutate any props that are passed in

**graph-view updates depend on immutability of props -- graph-view iterates through previous props and assesses what has changed, deletes what has been deleted, creates new objects, and renders things which have changed**