### PR TITLE
Disable pan or drag when ctrl / meta key are used

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -70,6 +70,7 @@ export type IGraphViewProps = {
   onUndo?: () => void,
   onUpdateNode: (node: INode) => void,
   panOnDrag?: boolean,
+  panOrDragWithCtrlMetaKey?: boolean,
   panOnWheel?: boolean,
   renderBackground?: (gridSize?: number) => any,
   renderDefs?: () => any,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -81,6 +81,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     rotateEdgeHandle: true,
     centerNodeOnMove: true,
     panOnDrag: true,
+    panOrDragWithCtrlMetaKey: true,
     panOnWheel: true,
   };
 
@@ -1338,6 +1339,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         key={id}
         id={id}
         data={node}
+        dragWithCtrlMetaKey={this.props.panOrDragWithCtrlMetaKey}
         nodeTypes={nodeTypes}
         nodeSize={nodeSize}
         nodeKey={nodeKey}
@@ -1731,7 +1733,13 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       return;
     }
 
-    const { clientX, clientY } = event;
+    const { clientX, clientY, ctrlKey, metaKey } = event;
+
+    if (!this.props.panOrDragWithCtrlMetaKey && (ctrlKey || metaKey)) {
+      event.preventDefault(); // don't show native context menus
+
+      return;
+    }
 
     this.panState = { clientX, clientY, requestId: null, panning: true };
     this.props.onPanDragStart();

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -61,6 +61,7 @@ type INodeProps = {
   ) => any,
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any,
   readOnly?: boolean,
+  dragWithCtrlMetaKey?: boolean,
   isSelected: boolean,
   layoutEngine?: any,
   viewWrapperElem: HTMLDivElement,
@@ -83,6 +84,7 @@ class Node extends React.Component<INodeProps, INodeState> {
   static defaultProps = {
     isSelected: false,
     readOnly: false,
+    dragWithCtrlMetaKey: true,
     nodeSize: 154,
     maxTitleChars: 12,
     scale: 1,
@@ -150,7 +152,7 @@ class Node extends React.Component<INodeProps, INodeState> {
     } = this.props;
 
     if (!mouseButtonDown) {
-      return;
+      return false;
     }
 
     // While the mouse is down, this function handles all mouse movement
@@ -194,18 +196,23 @@ class Node extends React.Component<INodeProps, INodeState> {
 
   handleDragStart = e => {
     if (!this.nodeRef.current) {
-      return;
+      return false;
     }
 
     const { drawingEdge } = this.state;
     const { data, onNodeSelected } = this.props;
 
     onNodeSelected(data, e.shiftKey || drawingEdge, e);
+
+    // if we don't want to drag with ctrl or meta, return false to exit drag
+    if (!this.props.dragWithCtrlMetaKey && (e.ctrlKey || e.metaKey)) {
+      return false;
+    }
   };
 
   handleDragEnd = e => {
     if (!this.nodeRef.current) {
-      return;
+      return false;
     }
 
     const { x, y, drawingEdge } = this.state;

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -574,6 +574,7 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
           onUndo={this.onUndo}
           onCopySelected={this.onCopySelected}
           onPasteSelected={this.onPasteSelected}
+          panOrDragWithCtrlMetaKey={false}
           layoutEngine={this.state.layoutEngine}
         />
       </div>


### PR DESCRIPTION
Adds `panOrDragWithCtrlMetaKey` prop.
- This prop disables pan if set to false and ctrl / meta key are used
- This props disables drag if set to false and ctrl / meta key are used
