### PR TITLE
Adds onZoomEnd for handling once zoom animations are complete.

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -69,6 +69,7 @@ export type IGraphViewProps = {
   onSwapEdge: (sourceNode: INode, targetNode: INode, edge: IEdge) => void,
   onUndo?: () => void,
   onUpdateNode: (node: INode) => void,
+  onZoomEnd?: () => void,
   panOnDrag?: boolean,
   panOnWheel?: boolean,
   renderBackground?: (gridSize?: number) => any,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -68,6 +68,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     onNodeMove: () => true,
     onPanDragStart: () => {},
     onPanDragEnd: () => {},
+    onZoomEnd: () => {},
     edgeArrowSize: 8,
     gridSpacing: 36,
     maxZoom: 1.5,
@@ -1061,7 +1062,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   handleZoomEnd = () => {
     const { draggingEdge, draggedEdge, edgeEndNode } = this.state;
-    const { nodeKey } = this.props;
+    const { nodeKey, onZoomEnd } = this.props;
+
+    // call on zoom end in the next animation frame
+    requestAnimationFrame(() => onZoomEnd());
 
     // mark zooming indicators as complete
     if (this.wheelState.zooming === true) {


### PR DESCRIPTION
@nvegesna will consume this in his panToNode work for tours. Rather than relying on approximate timeouts and monitoring to tell us when something is done zooming / panning, we can use this callback.