### PR TITLE
Fixes many many edge cases (!!!)

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -70,10 +70,10 @@ export type IGraphViewProps = {
   onUndo?: () => void,
   onUpdateNode: (node: INode) => void,
   onZoomEnd?: () => void,
-  customKeyEvents?: boolean,
   panOnDrag?: boolean,
   panOrDragWithCtrlMetaKey?: boolean,
   panOnWheel?: boolean,
+  disableGraphKeyHandlers?: boolean,
   renderBackground?: (gridSize?: number) => any,
   renderDefs?: () => any,
   renderNode?: (

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -70,6 +70,7 @@ export type IGraphViewProps = {
   onUndo?: () => void,
   onUpdateNode: (node: INode) => void,
   onZoomEnd?: () => void,
+  customKeyEvents?: boolean,
   panOnDrag?: boolean,
   panOrDragWithCtrlMetaKey?: boolean,
   panOnWheel?: boolean,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -81,6 +81,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     zoomDur: 750,
     rotateEdgeHandle: true,
     centerNodeOnMove: true,
+    customKeyEvents: true,
     panOnDrag: true,
     panOrDragWithCtrlMetaKey: true,
     panOnWheel: true,
@@ -153,8 +154,11 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   constructor(props: IGraphViewProps) {
     super(props);
 
+    // these track pan, wheel
     this.panState = { panning: false, requestId: null };
     this.wheelState = { zooming: false, requestId: null, deltaX: 0, deltaY: 0 };
+    this.initialZoomInProgress = true;
+
     this.nodeTimeouts = {};
     this.edgeTimeouts = {};
 
@@ -184,8 +188,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   componentDidMount() {
     const { initialBBox, minZoom, maxZoom } = this.props;
 
-    // TODO: can we target the element rather than the document?
-    document.addEventListener('keydown', this.handleWrapperKeydown);
+    if (this.props.customKeyEvents) {
+      document.addEventListener('keydown', this.handleWrapperKeydown);
+    }
+
     document.addEventListener('click', this.handleDocumentClick);
     document.addEventListener('mouseup', this.handlePanEnd);
 
@@ -219,30 +225,31 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         beforeRender: () => this.handleZoomToFitImpl(initialBBox, 0),
         afterRender: () => {},
       });
-
-      return;
-    }
-
-    this.renderView({
-      // without initialBBox, we hide then render the entities
-      // then zoom after rendering. upon zoom completion, we show the entities in handleZoomEnd
-      beforeRender: () => {
-        if (this.entities) {
-          this.entities.style.visibility = 'hidden';
-        }
-      },
-      afterRender: () => {
-        requestAnimationFrame(() => {
-          if (this.viewWrapper.current != null) {
-            this.handleZoomToFit(true);
+    } else {
+      this.renderView({
+        // without initialBBox, we hide then render the entities
+        // then zoom after rendering. upon zoom completion, we show the entities in handleZoomEnd
+        beforeRender: () => {
+          if (this.entities) {
+            this.entities.style.visibility = 'hidden';
           }
-        });
-      },
-    });
+        },
+        afterRender: () => {
+          requestAnimationFrame(() => {
+            if (this.viewWrapper.current != null) {
+              this.handleZoomToFit(true);
+            }
+          });
+        },
+      });
+    }
   }
 
   componentWillUnmount() {
-    document.removeEventListener('keydown', this.handleWrapperKeydown);
+    if (this.props.customKeyEvents) {
+      document.removeEventListener('keydown', this.handleWrapperKeydown);
+    }
+
     document.removeEventListener('click', this.handleDocumentClick);
     document.removeEventListener('mouseup', this.handlePanEnd);
 
@@ -644,32 +651,29 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   handleSvgClicked = (d: any, i: any) => {
     const {
-      onBackgroundClick,
-      onContextMenu,
       readOnly,
       onCreateNode,
+      onBackgroundClick,
+      onContextMenu,
     } = this.props;
 
-    if (this.isPartOfEdge(d3.event.target)) {
-      this.handleEdgeSelected(d3.event);
+    const event = d3.event;
+    const target = event.target;
+
+    if (this.isPartOfEdge(target)) {
+      this.handleEdgeSelected(event);
 
       return; // If any part of the edge is clicked, return
     }
 
-    if (!d3.event.shiftKey && onBackgroundClick) {
-      const xycoords = d3.mouse(d3.event.target);
+    const [x, y] = d3.mouse(target);
 
-      onBackgroundClick(xycoords[0], xycoords[1], d3.event);
-    }
-
-    if (
-      !d3.event.shiftKey &&
-      d3.event.type === 'contextmenu' &&
-      onContextMenu
-    ) {
-      const xycoords = d3.mouse(d3.event.target);
-
-      onContextMenu(xycoords[0], xycoords[1], d3.event);
+    if (target.classList.contains('background')) {
+      if (onContextMenu && event.type === 'contextmenu') {
+        onContextMenu(x, y, event);
+      } else if (onBackgroundClick) {
+        onBackgroundClick(x, y, event);
+      }
     }
 
     // de-select the current selection
@@ -678,10 +682,8 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       svgClicked: true,
     });
 
-    if (!readOnly && d3.event.shiftKey) {
-      const xycoords = d3.mouse(d3.event.target);
-
-      onCreateNode(xycoords[0], xycoords[1], d3.event);
+    if (!readOnly && event.shiftKey) {
+      onCreateNode(x, y, event);
     }
   };
 
@@ -1073,9 +1075,13 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       this.wheelState.zooming = false;
     }
 
-    // display hidden entity elements
-    if (this.entities && this.entities.style.visibility === 'hidden') {
-      this.entities.style.visibility = 'visible';
+    if (this.initialZoomInProgress) {
+      this.initialZoomInProgress = false;
+
+      // display hidden entity elements
+      if (this.entities && this.entities.style.visibility === 'hidden') {
+        this.entities.style.visibility = 'visible';
+      }
     }
 
     if (!draggingEdge || !draggedEdge) {
@@ -1679,7 +1685,6 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
               backgroundFillId={backgroundFillId}
               renderBackground={renderBackground}
             />
-
             <g className="entities" ref={el => (this.entities = el)} />
           </g>
         </svg>
@@ -1692,7 +1697,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   handlePanWheel = (event: any) => {
-    if (!this.props.panOnWheel) {
+    if (!this.props.panOnWheel || this.initialZoomInProgress) {
       return;
     }
 
@@ -1733,15 +1738,16 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   handlePanStart = (event: any) => {
-    if (!this.props.panOnDrag) {
+    if (!this.props.panOnDrag || this.initialZoomInProgress) {
       return;
     }
 
-    const { clientX, clientY, ctrlKey, metaKey } = event;
+    const { clientX, clientY, ctrlKey, metaKey, button } = event;
 
-    if (!this.props.panOrDragWithCtrlMetaKey && (ctrlKey || metaKey)) {
-      event.preventDefault(); // don't show native context menus
-
+    if (
+      (!this.props.panOrDragWithCtrlMetaKey && (ctrlKey || metaKey)) ||
+      button !== 0
+    ) {
       return;
     }
 

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1476,6 +1476,9 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     );
 
     if (nodeContainer) {
+      // we need to re-trigger the 'click', since we've disconnected mouseup from
+      // mousedown via re-appending (see node handleDragStart, handleDragEnd)
+      node.forceDragClick = true;
       this.entities.appendChild(nodeContainer);
     }
   }

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -81,7 +81,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     zoomDur: 750,
     rotateEdgeHandle: true,
     centerNodeOnMove: true,
-    customKeyEvents: true,
+    disableGraphKeyHandlers: false,
     panOnDrag: true,
     panOrDragWithCtrlMetaKey: true,
     panOnWheel: true,
@@ -188,7 +188,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   componentDidMount() {
     const { initialBBox, minZoom, maxZoom } = this.props;
 
-    if (this.props.customKeyEvents) {
+    if (!this.props.disableGraphKeyHandlers) {
       document.addEventListener('keydown', this.handleWrapperKeydown);
     }
 
@@ -246,7 +246,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   componentWillUnmount() {
-    if (this.props.customKeyEvents) {
+    if (!this.props.disableGraphKeyHandlers) {
       document.removeEventListener('keydown', this.handleWrapperKeydown);
     }
 
@@ -522,8 +522,11 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     });
 
     // remove from UI
-    removedNodes.forEach(nodeId =>
-      GraphUtils.removeElementFromDom(this.entities, `node-${nodeId}-container`)
+    removedNodes.forEach(node =>
+      GraphUtils.removeElementFromDom(
+        this.entities,
+        `node-${node[nodeKey]}-container`
+      )
     );
 
     // inform consumer

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -36,6 +36,7 @@ export type INode = {
   type?: string | null,
   subtype?: string | null,
   readOnly?: boolean | null,
+  forceDragClick?: boolean | null,
   [key: string]: any,
 };
 
@@ -202,6 +203,7 @@ class Node extends React.Component<INodeProps, INodeState> {
     const { drawingEdge } = this.state;
     const { data, onNodeSelected } = this.props;
 
+    data.forceDragClick = false;
     onNodeSelected(data, e.shiftKey || drawingEdge, e);
 
     // if we don't want to drag with ctrl or meta, return false to exit drag
@@ -229,14 +231,16 @@ class Node extends React.Component<INodeProps, INodeState> {
 
     onNodeUpdate({ x, y }, data[nodeKey], shiftKey || drawingEdge);
 
-    // we need to re-trigger the 'click', since we've disconnected mouseup from
-    // mousedown in handleDragStart()
-    const target = e.target;
-    const options = Object.assign(e);
+    if (data.forceDragClick) {
+      // we need to re-trigger the 'click', since we've disconnected mouseup from
+      // mousedown via dragging (see graph-view asyncElevateNodeAndEdges)
+      const target = e.target;
+      const options = Object.assign(e);
 
-    window.requestAnimationFrame(() => {
-      target.dispatchEvent(new MouseEvent('click', options));
-    });
+      window.requestAnimationFrame(() => {
+        target.dispatchEvent(new MouseEvent('click', options));
+      });
+    }
   };
 
   handleMouseOver = (event: any) => {


### PR DESCRIPTION
- disables pan (wheel or drag) if we're in the initialization of the canvas
- disables pan by drag on any click except left click
- adds prop to eliminate custom key events
- makes sure that onBackgroundClick and onContextMenu are only fired if the target is actually the background
- remove double mouse click firing by tracking a 'forceDragClick' data variable passed into a node: when a node is dragged, it sets 'forceDragClick' to false; the graph-view, when it z-index repositions the node, sets 'forceDragClick' to true; if the drag ends before the graph-view repositions the index, 'forceDragClick' is still false, no click is fired; if the drag ends after the reposition, 'forceDragClick' is true and we fire a custom event because we have repositioned and separated mouse up from mouse down*.

* note there is a reproducible edge case that occurs if you hammer the node (mouse up + mouse down, mouse up + mouse down, mouse up + mouse down) but in this case, click events are noisy anyway -- browsers don't guarantee consistency of click events so why should we :) 