### PR TITLE
Fix race conditions in initial load of graph-view

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1748,7 +1748,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   handlePanStart = (event: any) => {
-    if (!this.props.panOnDrag || this.initialZoomInProgress) {
+    if (!this.props.panOnDrag) {
       return;
     }
 


### PR DESCRIPTION
Previously, if the graph view was rendered multiple times before initialization was complete, existing animation frames would be canceled in favor of new ones.

This posed a problem for the strategy of hiding the graph until render was complete -- we had no clean way of tracking _when_ a render was complete.

Here, we just track "nextRendered". We also ease up checks on this.state.viewTransform and opt to just assume it is `{ x: 0, y: 0, k: 1 }` if not given.