### PR TITLE
zooming from center point

### DIFF
--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -645,43 +645,6 @@ describe('GraphView component', () => {
     });
   });
 
-  describe('modifyDiscreteZoom', () => {
-    beforeEach(() => {
-      spyOn(instance, 'setZoom');
-      instance.viewWrapper = {
-        current: document.createElement('div'),
-      };
-
-      instance.setState({
-        viewTransform: {
-          k: 0.4,
-          x: 50,
-          y: 50,
-        },
-      });
-    });
-
-    it('modifies the zoom', () => {
-      instance.modifyDiscreteZoom(0.2, 5, 10, 100);
-      expect(instance.setZoom).toHaveBeenCalledWith(
-        0.2,
-        -1, 
-        -2,
-        100
-      );
-    });
-
-    it('does nothing when targetZoom is too small', () => {
-      instance.modifyDiscreteZoom(-100, 5, 10, 100);
-      expect(instance.setZoom).not.toHaveBeenCalled();
-    });
-
-    it('does nothing when targetZoom is too large', () => {
-      instance.modifyZoom(100, 5, 10, 100);
-      expect(instance.setZoom).not.toHaveBeenCalled();
-    });
-  });
-
   describe('handleZoomToFit method', () => {
     beforeEach(() => {
       spyOn(instance, 'setZoom');

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1256,46 +1256,6 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     return true;
   };
 
-  // Updates current viewTransform to the given zoom level and pans to clicked area
-  modifyDiscreteZoom = (
-    zoomLevel: number = 0,
-    x: number = 0,
-    y: number = 0,
-    dur: number = 0
-  ) => {
-    const { viewTransform } = this.state;
-    const extent = this.zoom.scaleExtent();
-
-    const parent = d3.select(this.viewWrapper.current).node();
-    const centerX = parent.clientWidth / 2;
-    const centerY = parent.clientHeight / 2;
-
-    const next = {
-      k: viewTransform.k,
-      x: viewTransform.x,
-      y: viewTransform.y,
-    };
-
-    if (zoomLevel < extent[0] || zoomLevel > extent[1]) {
-      return false;
-    }
-
-    next.k = zoomLevel;
-
-    const dx = x * zoomLevel;
-    const dy = y * zoomLevel;
-
-    const newX = dx + viewTransform.x;
-    const newY = dy + viewTransform.y;
-
-    next.x = centerX - newX + viewTransform.x;
-    next.y = centerY - newY + viewTransform.y;
-
-    this.setZoom(next.k, next.x, next.y, dur);
-
-    return true;
-  };
-
   // Programmatically resets zoom
   setZoom(k: number = 1, x: number = 0, y: number = 0, dur: number = 0) {
     if (!this.viewWrapper.current) {
@@ -1309,6 +1269,18 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       .transition()
       .duration(dur)
       .call(this.zoom.transform, t);
+  }
+
+  setDiscreteZoom(k: number = 1, dur: number = 0, point: array) {
+    if (!this.viewWrapper.current) {
+      return;
+    }
+
+    d3.select(this.viewWrapper.current)
+      .select('svg')
+      .transition()
+      .duration(dur)
+      .call(this.zoom.scaleTo, k, point);
   }
 
   renderView({ beforeRender, afterRender }) {


### PR DESCRIPTION
Changing the zoom interaction to scale from the center - example below (git doesn't recognize `.mov` files so it's a `.gif` file which is why it's so slow)

Removing the previous interaction as it's not needed anymore
![Screen-Recording-2020-04-09-at-11 47 48-AM](https://user-images.githubusercontent.com/23197955/78916374-60087100-7a5b-11ea-85c8-4522274d649c.gif)


