### PR TITLE
passing in current view state in onZoomEnd callback

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1080,11 +1080,16 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   handleZoomEnd = () => {
-    const { draggingEdge, draggedEdge, edgeEndNode } = this.state;
+    const {
+      draggingEdge,
+      draggedEdge,
+      edgeEndNode,
+      viewTransform,
+    } = this.state;
     const { nodeKey, onZoomEnd } = this.props;
 
     // call on zoom end in the next animation frame
-    requestAnimationFrame(() => onZoomEnd());
+    requestAnimationFrame(() => onZoomEnd(viewTransform));
 
     // mark zooming indicators as complete
     if (this.wheelState.zooming === true) {


### PR DESCRIPTION
In order to make updates to the zoom functionality (and make it more discoverable), we need to know the current zoom state, so passing back the current `viewTransform`