### PR TITLE
remove extra call after rename

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -74,7 +74,7 @@ export type IGraphViewProps = {
   onSwapEdge: (sourceNode: INode, targetNode: INode, edge: IEdge) => void,
   onUndo?: () => void,
   onUpdateNode: (node: INode) => void,
-  onZoomStart: (viewTransform: object) => void,
+  onZoomStart?: (viewTransform: object) => void,
   onZoomEnd?: (viewTransform: object) => void,
   panOnDrag?: boolean,
   panOrDragWithCtrlMetaKey?: boolean,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1305,8 +1305,6 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     this.props.onZoomStart({ k, x, y });
 
-    this.props.onZoomCall({ k, x, y });
-
     d3.select(this.viewWrapper.current)
       .select('svg')
       .transition()


### PR DESCRIPTION
Removes the extra call accidentally left in after I renamed