### PR TITLE
Selecting nodes with shift in flow-view conflicts with current react-digraph behavior

### DIFF
--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -258,7 +258,7 @@ describe('GraphView component', () => {
   describe('renderEdge method', () => {
     beforeEach(() => {
       instance.entities = {
-        appendChild: jasmine.createSpy(),
+        prepend: jasmine.createSpy(),
         querySelector: () => null,
       };
       ReactDOM.render = jasmine.createSpy();
@@ -273,7 +273,7 @@ describe('GraphView component', () => {
 
       instance.renderEdge(element, edge);
 
-      expect(instance.entities.appendChild).toHaveBeenCalled();
+      expect(instance.entities.prepend).toHaveBeenCalled();
     });
 
     it('replaces an edge in an existing container', () => {
@@ -289,7 +289,7 @@ describe('GraphView component', () => {
 
       instance.renderEdge(element, edge);
 
-      expect(instance.entities.appendChild).not.toHaveBeenCalled();
+      expect(instance.entities.prepend).not.toHaveBeenCalled();
       expect(ReactDOM.render).toHaveBeenCalledWith(element, container);
     });
   });
@@ -1041,7 +1041,7 @@ describe('GraphView component', () => {
     });
 
     it('calls panToEntity on the appropriate node', () => {
-      instance.panToNode('a1');
+      instance.panToNode('a1', false);
       expect(instance.panToEntity).toHaveBeenCalledWith(entity, false);
     });
   });
@@ -1055,11 +1055,11 @@ describe('GraphView component', () => {
       instance.panToEntity = jest.fn();
 
       instance.entities = document.createElement('g');
-      instance.entities.appendChild(entity);
+      instance.entities.prepend(entity);
     });
 
     it('calls panToEntity on the appropriate edge', () => {
-      instance.panToEdge('a1', 'a2');
+      instance.panToEdge('a1', 'a2', false);
       expect(instance.panToEntity).toHaveBeenCalledWith(entity, false);
     });
   });

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -32,7 +32,6 @@ export type IInitialPosition = {
 
 export type IGraphViewProps = {
   backgroundFillId?: string,
-  createNodesAndEdgesOnShift?: boolean,
   edges: any[],
   edgeArrowSize?: number,
   edgeHandleSize?: number,

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -32,6 +32,7 @@ export type IInitialPosition = {
 
 export type IGraphViewProps = {
   backgroundFillId?: string,
+  createNodesAndEdgesOnShift?: boolean,
   edges: any[],
   edgeArrowSize?: number,
   edgeHandleSize?: number,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -56,7 +56,6 @@ type IGraphViewState = {
 
 class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   static defaultProps = {
-    createNodesAndEdgesOnShift: false,
     canCreateEdge: (startNode?: INode, endNode?: INode) => true,
     canDeleteEdge: () => true,
     canDeleteNode: () => true,
@@ -668,7 +667,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   handleSvgClicked = (d: any, i: any) => {
     const {
-      createNodesAndEdgesOnShift,
+      disableGraphKeyHandlers,
       readOnly,
       onCreateNode,
       onBackgroundClick,
@@ -700,7 +699,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       svgClicked: true,
     });
 
-    if (!readOnly && createNodesAndEdgesOnShift && event.shiftKey) {
+    if (!readOnly && !disableGraphKeyHandlers && event.shiftKey) {
       onCreateNode(x, y, event);
     }
   };
@@ -833,7 +832,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   handleNodeUpdate = (position: IPoint, nodeId: string, shiftKey: boolean) => {
-    const { createNodesAndEdgesOnShift, onUpdateNode, readOnly } = this.props;
+    const { disableGraphKeyHandlers, onUpdateNode, readOnly } = this.props;
 
     if (readOnly) {
       return;
@@ -841,7 +840,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     // Detect if edge is being drawn and link to hovered node
     // This will handle a new edge
-    if (shiftKey && createNodesAndEdgesOnShift) {
+    if (shiftKey && !disableGraphKeyHandlers) {
       this.createNewEdge();
     } else {
       const nodeMapNode: INodeMapNode | null = this.getNodeById(nodeId);
@@ -1384,7 +1383,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       <Node
         key={id}
         id={id}
-        createNodesAndEdgesOnShift={this.props.createNodesAndEdgesOnShift}
+        disableGraphKeyHandlers={this.props.disableGraphKeyHandlers}
         data={node}
         dragWithCtrlMetaKey={this.props.panOrDragWithCtrlMetaKey}
         nodeTypes={nodeTypes}

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -769,7 +769,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   handleNodeMove = (position: IPoint, nodeId: string, shiftKey: boolean) => {
-    const { createNodesAndEdgesOnShift, canCreateEdge, readOnly } = this.props;
+    const { canCreateEdge, readOnly } = this.props;
     const nodeMapNode: INodeMapNode | null = this.getNodeById(nodeId);
 
     if (readOnly || !nodeMapNode) {
@@ -778,10 +778,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     const node: INode = nodeMapNode.node;
 
-    if (
-      (!shiftKey && !this.state.draggingEdge) ||
-      !createNodesAndEdgesOnShift
-    ) {
+    if (!shiftKey && !this.state.draggingEdge) {
       this.positionNodes(position, node, true);
     } else if (
       (canCreateEdge && canCreateEdge(nodeId)) ||

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -43,6 +43,7 @@ export type INode = {
 type INodeProps = {
   data: INode,
   id: string,
+  createNodesAndEdgesOnShift?: boolean,
   nodeTypes: any, // TODO: make a nodeTypes interface
   nodeSubtypes: any, // TODO: make a nodeSubtypes interface
   opacity?: number,
@@ -83,6 +84,7 @@ type INodeState = {
 
 class Node extends React.Component<INodeProps, INodeState> {
   static defaultProps = {
+    createNodesAndEdgesOnShift: false,
     isSelected: false,
     readOnly: false,
     dragWithCtrlMetaKey: true,
@@ -145,6 +147,7 @@ class Node extends React.Component<INodeProps, INodeState> {
     const mouseButtonDown = e.buttons === 1;
     const shiftKey = e.shiftKey;
     const {
+      createNodesAndEdgesOnShift,
       nodeSize,
       nodeKey,
       viewWrapperElem,
@@ -171,7 +174,7 @@ class Node extends React.Component<INodeProps, INodeState> {
       newState.y -= newState.pointerOffset.y;
     }
 
-    if (shiftKey) {
+    if (shiftKey && createNodesAndEdgesOnShift) {
       this.setState({ drawingEdge: true });
       // draw edge
       // undo the target offset subtraction done by Edge
@@ -201,13 +204,22 @@ class Node extends React.Component<INodeProps, INodeState> {
     }
 
     const { drawingEdge } = this.state;
-    const { data, onNodeSelected } = this.props;
+    const {
+      data,
+      createNodesAndEdgesOnShift,
+      dragWithCtrlMetaKey,
+      onNodeSelected,
+    } = this.props;
 
     data.forceDragClick = false;
-    onNodeSelected(data, e.shiftKey || drawingEdge, e);
+    onNodeSelected(
+      data,
+      (e.shiftKey && createNodesAndEdgesOnShift) || drawingEdge,
+      e
+    );
 
     // if we don't want to drag with ctrl or meta, return false to exit drag
-    if (!this.props.dragWithCtrlMetaKey && (e.ctrlKey || e.metaKey)) {
+    if (!dragWithCtrlMetaKey && (e.ctrlKey || e.metaKey)) {
       return false;
     }
   };

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -211,15 +211,21 @@ class Node extends React.Component<INodeProps, INodeState> {
       onNodeSelected,
     } = this.props;
 
+    const { ctrlKey, metaKey, shiftKey } = e;
+
     data.forceDragClick = false;
     onNodeSelected(
       data,
-      (e.shiftKey && createNodesAndEdgesOnShift) || drawingEdge,
+      (shiftKey && createNodesAndEdgesOnShift) || drawingEdge,
       e
     );
 
     // if we don't want to drag with ctrl or meta, return false to exit drag
-    if (!dragWithCtrlMetaKey && (e.ctrlKey || e.metaKey)) {
+    // don't allow drag on shift when selecting node
+    if (
+      (!dragWithCtrlMetaKey && (ctrlKey || metaKey)) ||
+      (!createNodesAndEdgesOnShift && shiftKey)
+    ) {
       return false;
     }
   };

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -43,7 +43,7 @@ export type INode = {
 type INodeProps = {
   data: INode,
   id: string,
-  createNodesAndEdgesOnShift?: boolean,
+  disableGraphKeyHandlers?: boolean,
   nodeTypes: any, // TODO: make a nodeTypes interface
   nodeSubtypes: any, // TODO: make a nodeSubtypes interface
   opacity?: number,
@@ -84,7 +84,7 @@ type INodeState = {
 
 class Node extends React.Component<INodeProps, INodeState> {
   static defaultProps = {
-    createNodesAndEdgesOnShift: false,
+    disableGraphKeyHandlers: false,
     isSelected: false,
     readOnly: false,
     dragWithCtrlMetaKey: true,
@@ -147,7 +147,7 @@ class Node extends React.Component<INodeProps, INodeState> {
     const mouseButtonDown = e.buttons === 1;
     const shiftKey = e.shiftKey;
     const {
-      createNodesAndEdgesOnShift,
+      disableGraphKeyHandlers,
       nodeSize,
       nodeKey,
       viewWrapperElem,
@@ -174,7 +174,7 @@ class Node extends React.Component<INodeProps, INodeState> {
       newState.y -= newState.pointerOffset.y;
     }
 
-    if (shiftKey && createNodesAndEdgesOnShift) {
+    if (shiftKey && !disableGraphKeyHandlers) {
       this.setState({ drawingEdge: true });
       // draw edge
       // undo the target offset subtraction done by Edge
@@ -206,7 +206,7 @@ class Node extends React.Component<INodeProps, INodeState> {
     const { drawingEdge } = this.state;
     const {
       data,
-      createNodesAndEdgesOnShift,
+      disableGraphKeyHandlers,
       dragWithCtrlMetaKey,
       onNodeSelected,
     } = this.props;
@@ -216,7 +216,7 @@ class Node extends React.Component<INodeProps, INodeState> {
     data.forceDragClick = false;
     onNodeSelected(
       data,
-      (shiftKey && createNodesAndEdgesOnShift) || drawingEdge,
+      (shiftKey && !disableGraphKeyHandlers) || drawingEdge,
       e
     );
 
@@ -224,7 +224,7 @@ class Node extends React.Component<INodeProps, INodeState> {
     // don't allow drag on shift when selecting node
     if (
       (!dragWithCtrlMetaKey && (ctrlKey || metaKey)) ||
-      (!createNodesAndEdgesOnShift && shiftKey)
+      (disableGraphKeyHandlers && shiftKey)
     ) {
       return false;
     }


### PR DESCRIPTION
Shift+click is currently used to add nodes on the background and to create new edges when dragging nodes in `react-digraph`, added a new prop to disable this  (default is false) so that we can use shift to select multiple nodes in Trifacta

I believe I managed to gate every place utilizing the shift key, but also we don't use any of this in the flow view (we don't do anything on shift+background click and we return false for `canCreateEdge`), so there's also an argument to be had for just removing it all, but not sure if in the future it might have benefits.

The `disableGraphKeyHandlers` prop is also already being utilized in the Trifacta repo and doesn't account for this case, which is why this is necessary