### PR TITLE
Adding checks in to avoid errors in console

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1297,23 +1297,13 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       .select('svg')
       .node();
 
-    try {
-      const doesHeightValueExist =
-        svgNode.height &&
-        svgNode.height.baseVal &&
-        svgNode.height.baseVal.value;
-      const doesWidthValueExist =
-        svgNode.width && svgNode.width.baseVal && svgNode.width.baseVal.value;
+    if (svgNode != null) {
+      const bbox = svgNode.getBBox ? svgNode.getBBox() : null;
 
-      return (doesHeightValueExist && doesWidthValueExist) || true;
-    } catch (err) {
-      // fail gracefully and still display hidden entity elements even though the first zoom hasn't happened
-      if (this.entities && this.entities.style.visibility === 'hidden') {
-        this.entities.style.visibility = 'visible';
-      }
-
-      return false;
+      return bbox && bbox.width && bbox.height;
     }
+
+    return false;
   };
 
   // Programmatically resets zoom
@@ -1323,7 +1313,14 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     y: number = 0,
     dur: number = 0
   ) {
-    if (!this.viewWrapper.current || !this.shouldGraphZoom()) {
+    if (!this.viewWrapper.current) {
+      return;
+    } else if (!this.shouldGraphZoom()) {
+      // fail gracefully and still display hidden entity elements even though the first zoom hasn't happened
+      if (this.entities && this.entities.style.visibility === 'hidden') {
+        this.entities.style.visibility = 'visible';
+      }
+
       return;
     }
 
@@ -1339,7 +1336,14 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   zoomToPoint(k: number = 1, dur: number = 0, point: array) {
-    if (!this.viewWrapper.current || !this.shouldGraphZoom()) {
+    if (!this.viewWrapper.current) {
+      return;
+    } else if (!this.shouldGraphZoom()) {
+      // fail gracefully and still display hidden entity elements even though the first zoom hasn't happened
+      if (this.entities && this.entities.style.visibility === 'hidden') {
+        this.entities.style.visibility = 'visible';
+      }
+
       return;
     }
 

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1291,6 +1291,31 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     return true;
   };
 
+  shouldGraphZoom = () => {
+    const svgNode = d3
+      .select(this.viewWrapper.current)
+      .select('svg')
+      .node();
+
+    try {
+      const doesHeightValueExist =
+        svgNode.height &&
+        svgNode.height.baseVal &&
+        svgNode.height.baseVal.value;
+      const doesWidthValueExist =
+        svgNode.width && svgNode.width.baseVal && svgNode.width.baseVal.value;
+
+      return (doesHeightValueExist && doesWidthValueExist) || true;
+    } catch (err) {
+      // fail gracefully and still display hidden entity elements even though the first zoom hasn't happened
+      if (this.entities && this.entities.style.visibility === 'hidden') {
+        this.entities.style.visibility = 'visible';
+      }
+
+      return false;
+    }
+  };
+
   // Programmatically resets zoom
   zoomAndTranslate(
     k: number = 1,
@@ -1298,7 +1323,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     y: number = 0,
     dur: number = 0
   ) {
-    if (!this.viewWrapper.current) {
+    if (!this.viewWrapper.current || !this.shouldGraphZoom()) {
       return;
     }
 
@@ -1314,15 +1339,17 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   zoomToPoint(k: number = 1, dur: number = 0, point: array) {
-    if (!this.viewWrapper.current) {
+    if (!this.viewWrapper.current || !this.shouldGraphZoom()) {
       return;
     }
 
-    this.props.onZoomStart({
-      k,
-      x: this.state.viewTransform.x,
-      y: this.state.viewTransform.y,
-    });
+    if (this.state.viewTransform) {
+      this.props.onZoomStart({
+        k,
+        x: this.state.viewTransform.x,
+        y: this.state.viewTransform.y,
+      });
+    }
 
     d3.select(this.viewWrapper.current)
       .select('svg')


### PR DESCRIPTION
Creating a try/catch to catch the `Failed to read the 'value' property from 'SVGLength': Could not resolve relative length.` error - just stops the zoom from even happening.

Also shows the entities if they were previously hidden to avoid cases where the initial zoom errors out - it will likely be at 100% zoom level, but it's a better UX than the screen just being blank.