### PR TITLE
Adjusting calculations for initial position

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -28,6 +28,8 @@ export type IBBox = {
 export type IInitialPosition = {
   x?: number,
   y?: number,
+  k?: number,
+  alignWith?: string,
 };
 
 export type IGraphViewProps = {

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1192,10 +1192,28 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     const next = this.computeZoom(viewBBox);
 
+    /* 
+    If the initial position should be aligned with the entities rather than the graph, need to account for where the entities are positioned
+    Subtract the bounding box coordinates and adjust for the scale of the graph
+    */
+    if (initialPosition.x) {
+      next.x =
+        initialPosition.alignWith === 'entities'
+          ? (initialPosition.x - viewBBox.x) * next.k
+          : initialPosition.x;
+    }
+
+    if (initialPosition.y) {
+      next.y =
+        initialPosition.alignWith === 'entities'
+          ? (initialPosition.y - viewBBox.y) * next.k
+          : initialPosition.y;
+    }
+
     this.zoomAndTranslate(
-      next.k,
-      initialPosition.x ? initialPosition.x : next.x,
-      initialPosition.y ? initialPosition.y : initialPosition.y,
+      initialPosition.k ? initialPosition.k : next.k,
+      next.x,
+      next.y,
       0
     );
   };

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1192,30 +1192,29 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     const next = this.computeZoom(viewBBox);
 
+    if (initialPosition.k) {
+      next.k = initialPosition.k;
+    }
+
     /* 
-    If the initial position should be aligned with the entities rather than the graph, need to account for where the entities are positioned
-    Subtract the bounding box coordinates and adjust for the scale of the graph
+    If the initial position should be aligned with the entities rather than the graph, need to account for where the entities are positioned (subtract bbox)
+    Also need to adjust for the scale of the graph
     */
     if (initialPosition.x) {
       next.x =
         initialPosition.alignWith === 'entities'
           ? (initialPosition.x - viewBBox.x) * next.k
-          : initialPosition.x;
+          : initialPosition.x * next.k;
     }
 
     if (initialPosition.y) {
       next.y =
         initialPosition.alignWith === 'entities'
           ? (initialPosition.y - viewBBox.y) * next.k
-          : initialPosition.y;
+          : initialPosition.y * next.k;
     }
 
-    this.zoomAndTranslate(
-      initialPosition.k ? initialPosition.k : next.k,
-      next.x,
-      next.y,
-      0
-    );
+    this.zoomAndTranslate(next.k, next.x, next.y, 0);
   };
 
   computeZoom(viewBBox) {


### PR DESCRIPTION
Updating the calculation of the initial position prop
- passes in a new `alignWith` attribute to the `initialPosition` object, to either align the initial position with the top-left corner of the whole graph or just the entities (this is so the plan graphs won't be messed up by these changes)
- passes in a new `k` (scale) prop to the `initialPosition` -> we don't need this currently, but Alex had potentially wanted to start the graph off at 100% scale so I figured might as well just update it now in case we use it later
- adjusts for the different scales that a graph can have (in flow)
