### PR TITLE
Extend initial position zoom method to handle all zooms with a given position

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,15 @@ All props are detailed below.
 | onSwapEdge          | func                    | true      | Called when an edge 'target' is swapped.                  |
 | onDeleteEdge        | func                    | true      | Called when an edge is deleted.                           |
 | onBackgroundClick   | func                    | false     | Called when the background is clicked.                    |
+| onContextMenu       | func                    |  false    | Called when the background is right clicked.              |
+| onPanDragStart      | func                    | false     | Called when graph starts panning.                         |
+| onPanDragEnd        | func                    | false     | Called after graph ends panning.                          |
+| onZoomStart         | func                    | false     | Called when a zoom starts.                                |
+| onZoomEnd           | func                    | false     | Called after a zoom ends.                                 |
 | canDeleteNode       | func                    | false     | Called before a node is deleted.                          |
 | canCreateEdge       | func                    | false     | Called before an edge is created.                         |
 | canDeleteEdge       | func                    | false     | Called before an edge is deleted.                         |
-| afterRenderEdge      | func                    | false     | Called after an edge is rendered.                         |
+| afterRenderEdge     | func                    | false     | Called after an edge is rendered.                         |
 | renderNode          | func                    | false     | Called to render node geometry.                           |
 | renderNodeText      | func                    | false     | Called to render the node text                            |
 | renderDefs          | func                    | false     | Called to render svg definitions.                         |
@@ -231,8 +236,13 @@ All props are detailed below.
 | edgeHandleSize      | number                  | false     | Edge handle size.                                         |
 | edgeArrowSize       | number                  | false     | Edge arrow size.                                          |
 | zoomDelay           | number                  | false     | Delay before zoom occurs.                                 |
+| initialZoomDur      | number                  | false     | Delay before initial zoom occurs.                         |
 | zoomDur             | number                  | false     | Duration of zoom transition.                              |
+| panOnDrag           | boolean                 | false     | Whether the graph should pan when dragged.                                 |
+| panOrDragWithCtrlMetaKey           | boolean                  | false     | Whether the graph should pan when dragged and control/meta key is pressed.                                 |
+| panOnWheel          | boolean                 | false     | Whether the wheel should move the graph.                                 |
 | showGraphControls   | boolean                 | false     | Whether to show zoom controls.                            |
+| disableGraphKeyHandlers      | boolean                  | false     | Whether react-digraph's key handlers should be respected.                         |
 | layoutEngineType    | typeof LayoutEngineType | false     | Uses a pre-programmed layout engine, such as 'SnapToGrid' |
 | rotateEdgeHandle    | boolean                 | false     | Whether to rotate edge handle with edge when a node is moved |
 | centerNodeOnMove    | boolean                 | false     | Weather the node should be centered on cursor when moving a node    |
@@ -311,6 +321,42 @@ You can call these methods on the GraphView class using a ref.
 | ------------------|:---------------------------------------------------------:|  :-------------------------------------------------------------------------:|
 | panToNode         | (id: string, zoom?: boolean) => void                      | Center the node given by `id` within the viewport, optionally zoom in to fit it. |
 | panToEdge         | (source: string, target: string, zoom?: boolean) => void  | Center the edge between `source` and `target` node IDs within the viewport, optionally zoom in to fit it.  |
+| zoomAndTranslate         | (k: number, x: number, y: number, dur?: number) => void  | Zoom the graph based off the identity transform and translate it to the given x, y coords  |
+| zoomToPoint         | (k: number, dur?: number, point: array) => void  | Zoom the graph to the given `k` scale, optionally centered around the given point or the center of the screen  |
+
+## Connecting locally with Trifacta repo
+Steps to locally test `react-digraph` changes in the Trifacta repo.
+
+#### Trifacta repo
+In the Trifacta repo, navigate to `webpack.common` and paste the following near the top (such as below `JAVASCRIPT_BUILD_TOOLS_DIR`)
+
+Make sure to adjust your path to point to your local `react-digraph` folder!
+```
+const REACT_DIGRAPH_DIR = path.normalize(
+  path.join(REPO_ROOT, 'path', 'to', 'your', 'react-digraph-folder')
+);
+```
+
+Search for `amplitude$` and paste the following below it.
+```
+'react-digraph':path.join(REACT_DIGRAPH_DIR, '/dist/main.js'),
+```
+
+Rerun `make-build-client` 
+
+#### react-digraph repo
+Run `npm run watch`
+
+If it doesn't seem to be connecting, in `webpack.config.js` try changing `libraryTarget` to `commonjs2`.
+If that doesn't work, try removing the `dist` folder completely and re-running `npm run watch`
+
+## Adding a react-digraph sourcemap
+1. Open devtools
+2. Navigate to _filesystem_ -> _add folder to workspace_
+3. Check that your `react-digraph/dist` folder has a source map file (`main.min.js.map`)
+4. Add your local `react-digraph` folder
+5. Open the `main.min.js.map` file in devtools -> _right click_ -> _copy link_
+6. Open `main.min.js` and click _add source map_ -> _paste link_
 
 ## Deprecation Notes
 

--- a/README.md
+++ b/README.md
@@ -321,8 +321,9 @@ You can call these methods on the GraphView class using a ref.
 | ------------------|:---------------------------------------------------------:|  :-------------------------------------------------------------------------:|
 | panToNode         | (id: string, zoom?: boolean) => void                      | Center the node given by `id` within the viewport, optionally zoom in to fit it. |
 | panToEdge         | (source: string, target: string, zoom?: boolean) => void  | Center the edge between `source` and `target` node IDs within the viewport, optionally zoom in to fit it.  |
-| zoomAndTranslate         | (k: number, x: number, y: number, dur?: number) => void  | Zoom the graph based off the identity transform and translate it to the given x, y coords  |
 | zoomToPoint         | (k: number, dur?: number, point: array) => void  | Zoom the graph to the given `k` scale, optionally centered around the given point or the center of the screen  |
+| handleZoomWithPosition         | (position: IInitialPosition) => void  | Position the graph at the given `x` and `y` values adjusting for scale. Optionally align the graph with the entities or change the scale/zoom duration  |
+| handleZoomToFit         | (initialZoom: boolean) => void  | Zoom the graph to be centered and fit all the entities on screen.  |
 
 ## Connecting locally with Trifacta repo
 Steps to locally test `react-digraph` changes in the Trifacta repo.

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -30,6 +30,7 @@ export type IInitialPosition = {
   y?: number,
   k?: number,
   alignWith?: string,
+  dur?: number,
 };
 
 export type IGraphViewProps = {

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -235,7 +235,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
           requestAnimationFrame(() => {
             if (this.viewWrapper.current != null) {
               if (initialPosition) {
-                this.handleInitialZoom(initialPosition);
+                this.handleZoomWithPosition(initialPosition);
               } else {
                 this.handleZoomToFit(true);
               }
@@ -1177,7 +1177,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     );
   };
 
-  handleInitialZoom = (initialPosition: IInitialPosition) => {
+  handleZoomWithPosition = (position: IInitialPosition) => {
     const entities = d3.select(this.entities).node();
 
     if (!entities) {
@@ -1192,29 +1192,34 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     const next = this.computeZoom(viewBBox);
 
-    if (initialPosition.k) {
-      next.k = initialPosition.k;
+    if (position.k) {
+      next.k = position.k;
     }
 
     /* 
     If the initial position should be aligned with the entities rather than the graph, need to account for where the entities are positioned (subtract bbox)
     Also need to adjust for the scale of the graph
     */
-    if (initialPosition.x) {
+    if (position.x) {
       next.x =
-        initialPosition.alignWith === 'entities'
-          ? (initialPosition.x - viewBBox.x) * next.k
-          : initialPosition.x * next.k;
+        position.alignWith === 'entities'
+          ? (position.x - viewBBox.x) * next.k
+          : position.x * next.k;
     }
 
-    if (initialPosition.y) {
+    if (position.y) {
       next.y =
-        initialPosition.alignWith === 'entities'
-          ? (initialPosition.y - viewBBox.y) * next.k
-          : initialPosition.y * next.k;
+        position.alignWith === 'entities'
+          ? (position.y - viewBBox.y) * next.k
+          : position.y * next.k;
     }
 
-    this.zoomAndTranslate(next.k, next.x, next.y, 0);
+    this.zoomAndTranslate(
+      next.k,
+      next.x,
+      next.y,
+      position.dur ? position.dur : 0
+    );
   };
 
   computeZoom(viewBBox) {


### PR DESCRIPTION
Currently zoom to fit doesn't left align the graph for flow view. Instead of trying to adjust the zoom to fit math, just leverage the position method and make it a little more flexible.

Adding in the zoom duration so that when used for something aside from the initial position, it doesn't have a jump effect but has a transition.

Also updating the readme to have more helpful information about how to connect with Trifacta to test things locally