### PR TITLE
Add time out to remove async rendered nodes

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -416,18 +416,19 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         this.removeEdgeElement(edge);
       });
 
-      // remove node
+      // remove node - timeout helps for removing async rendered nodes
+      const nodeIdToRemove = `node-${nodeId}-container`;
+
+      setTimeout(
+        () => GraphUtils.removeElementFromDom(this.entities, nodeIdToRemove),
+        200
+      );
       // The animation frame avoids a race condition
       requestAnimationFrame(() => {
         const nodeRenderId = this.nodeRenderId(prevNode);
 
         // cancel anyone attempting to render this node
         cancelAnimationFrame(this.nodeTimeouts[nodeRenderId]);
-
-        GraphUtils.removeElementFromDom(
-          this.entities,
-          `node-${nodeId}-container`
-        );
       });
     }
   }


### PR DESCRIPTION
For bigger flows even though we are passing the right state, it seems for deleting nodes and multiple renders causing the deleted nodes to re-added to the dom. Timeout for remove essentially helps in deleting after for initial async render is done. Tested on flow upto 150 ish nodes works fine for nodes, this is short term fix, till we figure out and make bigger change if needed.