### PR TITLE
Support async layout engines, add Elk

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
   "plugins": [
+    ["transform-runtime", {
+      "polyfill": false,
+      "regenerator": true
+    }],
     "transform-object-assign",
     "transform-es2015-destructuring",
     "transform-object-rest-spread",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-addons-shallow-compare": "^15.6.2",
     "react-draggable": "^3.3.2",
     "svg-intersections": "^0.4.0",
-    "web-worker": "^1.0.0"
+    "web-worker": "^1.0.0",
+    "webcola": "3.4.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -31,14 +31,16 @@
   "dependencies": {
     "d3": "^5.7.0",
     "dagre": "^0.8.2",
+    "elkjs": "^0.7.0",
     "fast-deep-equal": "^2.0.1",
     "html-react-parser": "^0.6.1",
     "kld-affine": "2.0.4",
     "kld-intersections": "^0.4.3",
     "line-intersect": "^2.1.1",
-    "svg-intersections": "^0.4.0",
+    "react-addons-shallow-compare": "^15.6.2",
     "react-draggable": "^3.3.2",
-    "webcola": "3.4.0"
+    "svg-intersections": "^0.4.0",
+    "web-worker": "^1.0.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
@@ -52,6 +54,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -28,6 +28,7 @@ import GraphControls from './graph-controls';
 import GraphUtils, { type INodeMapNode } from '../utilities/graph-util';
 import Node, { type INode, type IPoint } from './node';
 import type { IInitialPosition, IBBox } from './graph-view-props';
+import shallowCompare from 'react-addons-shallow-compare';
 
 type IViewTransform = {
   k: number,
@@ -85,24 +86,17 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   static getDerivedStateFromProps(
-    nextProps: IGraphViewProps,
-    prevState: IGraphViewState
+    props: IGraphViewProps,
+    state: IGraphViewState
   ) {
-    const { edges, nodeKey } = nextProps;
-    let nodes = nextProps.nodes;
+    const { edges, nodeKey } = props;
+    const nodes = props.nodes;
     const nodesMap = GraphUtils.getNodesMap(nodes, nodeKey);
     const edgesMap = GraphUtils.getEdgesMap(edges);
 
     GraphUtils.linkNodesAndEdges(nodesMap, edges);
 
-    // Handle layoutEngine on initial render
-    if (prevState.nodes.length === 0 && nextProps.layoutEngine) {
-      const newNodes = nextProps.layoutEngine.adjustNodes(nodes, nodesMap);
-
-      nodes = newNodes;
-    }
-
-    const nextSelected = nextProps.selected || [];
+    const nextSelected = props.selected || [];
 
     const { selectedNodes, selectedEdges } = nextSelected.reduce(
       (memo, nodeKey) => {
@@ -124,12 +118,14 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     );
 
     const nextState = {
+      firstAdjustment: state.firstAdjustment,
+      adjusted: state.adjusted && shallowCompare(nodes, state.nodes),
       componentUpToDate: true,
       edges,
       edgesMap,
       nodes,
       nodesMap,
-      readOnly: nextProps.readOnly,
+      readOnly: props.readOnly,
       selectedEdges,
       selectedNodes,
     };
@@ -165,6 +161,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     this.graphSvg = React.createRef();
 
     this.state = {
+      mounted: false,
+      firstAdjustment: false,
+      ownUpdate: false,
+      adjusted: false,
       componentUpToDate: false,
       draggedEdge: null,
       draggingEdge: false,
@@ -184,6 +184,14 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   componentDidMount() {
+    if (!this.state.mounted) {
+      this.setState({
+        mounted: true,
+      });
+    }
+  }
+
+  onInitialRender() {
     const { initialBBox, initialPosition, minZoom, maxZoom } = this.props;
 
     if (!this.props.disableGraphKeyHandlers) {
@@ -273,7 +281,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       !nextState.componentUpToDate ||
       nextProps.selected !== this.props.selected ||
       nextProps.readOnly !== this.props.readOnly ||
-      nextProps.layoutEngine !== this.props.layoutEngine
+      nextProps.layoutEngine !== this.props.layoutEngine ||
+      nextState.adjusted !== this.state.adjusted ||
+      nextState.mounted !== this.state.mounted ||
+      nextState.firstAdjustment !== this.state.firstAdjustment
     ) {
       return true;
     }
@@ -281,8 +292,12 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     return false;
   }
 
-  componentDidUpdate(prevProps: IGraphViewProps, prevState: IGraphViewState) {
+  async componentDidUpdate(
+    prevProps: IGraphViewProps,
+    prevState: IGraphViewState
+  ) {
     const {
+      edges,
       nodesMap,
       edgesMap,
       nodes,
@@ -293,12 +308,20 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     const forceReRender = prevProps.layoutEngine !== layoutEngine;
 
-    if (forceReRender && layoutEngine) {
-      const newNodes = layoutEngine.adjustNodes(nodes, nodesMap);
+    if (
+      (forceReRender || (prevState.mounted === false && this.state.mounted)) &&
+      layoutEngine
+    ) {
+      const newNodes = await layoutEngine.adjustNodes(nodes, nodesMap);
 
       this.setState({
         nodes: newNodes,
+        adjusted: false,
       });
+    }
+
+    if (!this.state.firstAdjustment) {
+      this.onInitialRender();
     }
 
     // Note: the order is intentional
@@ -310,7 +333,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     // add new nodes
     this.addNewNodes(
-      this.state.nodes,
+      nodes,
       prevState.nodesMap,
       selectedNodes,
       prevState.selectedNodes,
@@ -319,7 +342,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     // add new edges
     this.addNewEdges(
-      this.state.edges,
+      edges,
       prevState.edgesMap,
       selectedEdges,
       prevState.selectedEdges,
@@ -328,6 +351,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     this.setState({
       componentUpToDate: true,
+      firstAdjustment: true,
     });
   }
 
@@ -1198,7 +1222,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       next.k = position.k;
     }
 
-    /* 
+    /*
     If the initial position should be aligned with the entities rather than the graph, need to account for where the entities are positioned (subtract bbox)
     Also need to adjust for the scale of the graph
     */
@@ -1768,7 +1792,12 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     return (
       <div className="view-wrapper" ref={this.viewWrapper}>
-        <svg className="graph" ref={this.graphSvg}>
+        <svg
+          data-ts="graph"
+          className="graph"
+          ref={this.graphSvg}
+          data-adjusted={this.state.firstAdjustment}
+        >
           <Defs
             edgeArrowSize={edgeArrowSize}
             gridSpacing={gridSpacing}

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -161,7 +161,6 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     this.graphSvg = React.createRef();
 
     this.state = {
-      mounted: false,
       firstAdjustment: false,
       ownUpdate: false,
       adjusted: false,
@@ -184,11 +183,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   componentDidMount() {
-    if (!this.state.mounted) {
-      this.setState({
-        mounted: true,
-      });
-    }
+    return this.layoutGraph(this.props, this.state);
   }
 
   onInitialRender() {
@@ -281,10 +276,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       !nextState.componentUpToDate ||
       nextProps.selected !== this.props.selected ||
       nextProps.readOnly !== this.props.readOnly ||
-      nextProps.layoutEngine !== this.props.layoutEngine ||
-      nextState.adjusted !== this.state.adjusted ||
-      nextState.mounted !== this.state.mounted ||
-      nextState.firstAdjustment !== this.state.firstAdjustment
+      nextProps.layoutEngine !== this.props.layoutEngine
     ) {
       return true;
     }
@@ -296,6 +288,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     prevProps: IGraphViewProps,
     prevState: IGraphViewState
   ) {
+    return this.layoutGraph(prevProps, prevState);
+  }
+
+  async layoutGraph(prevProps: IGraphViewProps, prevState: IGraphViewState) {
     const {
       edges,
       nodesMap,
@@ -306,12 +302,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     } = this.state;
     const { layoutEngine } = this.props;
 
-    const forceReRender = prevProps.layoutEngine !== layoutEngine;
+    const forceReRender =
+      prevProps.layoutEngine !== layoutEngine || !this.state.firstAdjustment;
 
-    if (
-      (forceReRender || (prevState.mounted === false && this.state.mounted)) &&
-      layoutEngine
-    ) {
+    if (forceReRender && layoutEngine) {
       const newNodes = await layoutEngine.adjustNodes(nodes, nodesMap);
 
       this.setState({

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -276,7 +276,8 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       !nextState.componentUpToDate ||
       nextProps.selected !== this.props.selected ||
       nextProps.readOnly !== this.props.readOnly ||
-      nextProps.layoutEngine !== this.props.layoutEngine
+      nextProps.layoutEngine !== this.props.layoutEngine ||
+      nextState.firstAdjustment !== this.state.firstAdjustment
     ) {
       return true;
     }

--- a/src/utilities/layout-engine/layout-engine-config.js
+++ b/src/utilities/layout-engine/layout-engine-config.js
@@ -18,14 +18,21 @@
 import None from './none';
 import SnapToGrid from './snap-to-grid';
 import VerticalTree from './vertical-tree';
+import VerticalOrderedTree from './vertical-ordered-tree';
 import HorizontalTree from './horizontal-tree';
 
-export type LayoutEngine = None | SnapToGrid | VerticalTree | HorizontalTree;
+export type LayoutEngine =
+  | None
+  | SnapToGrid
+  | VerticalTree
+  | HorizontalTree
+  | VerticalOrderedTree;
 
 const LayoutEngines = {
   None,
   SnapToGrid,
   VerticalTree,
+  VerticalOrderedTree,
   HorizontalTree,
 };
 

--- a/src/utilities/layout-engine/vertical-ordered-tree.js
+++ b/src/utilities/layout-engine/vertical-ordered-tree.js
@@ -1,0 +1,100 @@
+// eslint-disable-next-line flowtype/no-types-missing-file-annotation
+import { type INode } from '../../components/node';
+import SnapToGrid from './snap-to-grid';
+import ELK from 'elkjs/lib/elk.bundled.js';
+
+const elk = new ELK();
+
+class VerticalOrderedTree extends SnapToGrid {
+  // eslint-disable-next-line flowtype/no-types-missing-file-annotation
+  async adjustNodes(nodes: INode[], nodesMap?: any): INode[] {
+    const {
+      nodeKey,
+      nodeSize,
+      nodeHeight,
+      nodeWidth,
+      nodeSpacingMultiplier,
+    } = this.graphViewProps;
+
+    const graph = {
+      id: 'root',
+      children: [],
+      edges: [],
+      layoutOptions: {
+        'elk.direction': 'DOWN',
+        'elk.algorithm': 'layered',
+        considerModelOrder: 'NODES_AND_EDGES',
+        favorStraightEdges: false,
+        'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
+      },
+    };
+
+    const spacing = nodeSpacingMultiplier || 1.5;
+    const size = (nodeSize || 1) * spacing;
+    let height;
+    let width;
+
+    if (nodeHeight) {
+      height = nodeHeight * spacing;
+    }
+
+    if (nodeWidth) {
+      width = nodeWidth * spacing;
+    }
+
+    // TODO possibly modify depending on node IDs
+    nodes.sort(({ id }) => id);
+
+    nodes.forEach(node => {
+      if (!nodesMap) {
+        return;
+      }
+
+      const nodeId = node[nodeKey];
+      const nodeKeyId = `key-${nodeId}`;
+      const nodesMapNode = nodesMap[nodeKeyId];
+
+      if (
+        nodesMapNode.incomingEdges.length === 0 &&
+        nodesMapNode.outgoingEdges.length === 0
+      ) {
+        return;
+      }
+
+      graph.children.push({
+        id: nodeKeyId,
+        width: width || size,
+        height: height || size,
+      });
+
+      /*
+      const outgoingEdges = nodesMapNode.outgoingEdges;
+      // Need to modify this, currently the target IDs aren't consistently identifying the "adding" node
+      outgoingEdges.sort(edge => {
+        return parseInt(edge.target.replace(/^\D+/g, ''), 10);
+      });
+*/
+
+      nodesMapNode.outgoingEdges.forEach(edge => {
+        graph.edges.push({
+          id: `nodeKeyId-key-${edge.target}`,
+          sources: [nodeKeyId],
+          targets: [`key-${edge.target}`],
+        });
+      });
+    });
+
+    const result = await elk.layout(graph);
+
+    result.children.forEach(({ id, x, y }) => {
+      const nodesMapNode = nodesMap[id];
+
+      nodesMapNode.node.x = x;
+      nodesMapNode.node.y = y;
+    });
+
+    return nodes;
+  }
+}
+
+export default VerticalOrderedTree;


### PR DESCRIPTION
This modifies the graph to support async layout engines (e.g. [Elk](https://github.com/kieler/elkjs)) and adds it as a dependency. This is needed for the plan page, where we've so far used Dagre as the layout engine but ran into an issue where the order of nodes in any given rank were non-deterministic, which caused branches to swap places when the plan graph was modified by adding and removing nodes.